### PR TITLE
Use tensor id to avoid recompiling issue of FSDP

### DIFF
--- a/torch_xla/distributed/fsdp/utils.py
+++ b/torch_xla/distributed/fsdp/utils.py
@@ -3,6 +3,7 @@ from types import MethodType
 import torch
 from torch.distributed.utils import _apply_to_tensors
 from torch.utils.checkpoint import check_backward_validity, detach_variable
+import torch_xla
 import torch_xla.core.xla_model as xm
 from torch_xla.utils.checkpoint import checkpoint
 
@@ -291,3 +292,7 @@ def autograd_module(module):
       _xla_autograd_forward_no_kwargs, module)
   module.forward = MethodType(_forward_with_autograd, module)
   return module
+
+
+def get_tensor_id(t):
+  return torch_xla._XLAC._xla_get_tensor_id(t)

--- a/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
+++ b/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py
@@ -894,7 +894,9 @@ class XlaFullyShardedDataParallel(nn.Module):
     """Reset instance so :func:`_lazy_init` will run on the next forward."""
     self._is_root: Optional[bool] = None
     self._all_sharded_params: Optional[Parameter] = None
+    self._output_pre_backward_hook_registered: Optional[Set] = None
     self._backward_opt_barrier_tensors: Optional[List] = None
+    self._backward_opt_barrier_tensor_ids: Optional[Set] = None
     self.reshard_after_forward = self._orig_reshard_after_forward
     self._delayed_reduce_scatter: Optional[Dict] = None
     self._backward_opt_grads: Optional[Dict] = None
@@ -958,12 +960,16 @@ class XlaFullyShardedDataParallel(nn.Module):
     And a list to apply optimization barrier on backward pass tensors.
     """
     assert self._is_root, "This should only be called on the root"
+    self._output_pre_backward_hook_registered = set()
     self._backward_opt_barrier_tensors = []
+    self._backward_opt_barrier_tensor_ids = set()
     self._delayed_reduce_scatter = {}
     self._backward_opt_grads = {}
     for n, m in self.named_modules():
       if n != "" and isinstance(m, XlaFullyShardedDataParallel):
+        m._output_pre_backward_hook_registered = self._output_pre_backward_hook_registered
         m._backward_opt_barrier_tensors = self._backward_opt_barrier_tensors
+        m._backward_opt_barrier_tensor_ids = self._backward_opt_barrier_tensor_ids
         m._delayed_reduce_scatter = self._delayed_reduce_scatter
         m._backward_opt_grads = self._backward_opt_grads
 
@@ -1059,11 +1065,14 @@ class XlaFullyShardedDataParallel(nn.Module):
     """
     Add tensor to backward pass optimization barrier list if it is not there.
     """
-    self._backward_opt_barrier_tensors.append(tensor)
+    if id(tensor) not in self._backward_opt_barrier_tensor_ids:
+      self._backward_opt_barrier_tensor_ids.add(id(tensor))
+      self._backward_opt_barrier_tensors.append(tensor)
 
   def _clear_backward_opt_barrier_lists(self) -> None:
     """Reset the backward pass optimization barrier list"""
     self._backward_opt_barrier_tensors.clear()
+    self._backward_opt_barrier_tensor_ids.clear()
 
   def _register_grad_opt_barrier_hooks(
       self, dependency_tensors: List[torch.Tensor]) -> None:
@@ -1176,8 +1185,11 @@ class XlaFullyShardedDataParallel(nn.Module):
       # We don't register the pre_backward hook on the same tensor that has been
       # returned from an inner FSDP, unless it is the first one.
       nonlocal _registered
-      if t.requires_grad:
+      assert self._output_pre_backward_hook_registered is not None
+      if t.requires_grad and (_registered == 0 or id(t)
+                              not in self._output_pre_backward_hook_registered):
         t.register_hook(_pre_backward_hook)
+        self._output_pre_backward_hook_registered.add(id(t))
         _registered += 1
       return t
 
@@ -1430,6 +1442,8 @@ class XlaFullyShardedDataParallel(nn.Module):
           # reset this flag for cases like "one forward pass + multiple backward passes"
           self._post_backward_callback_queued = False
           # clear this list for next iteration
+          assert self._output_pre_backward_hook_registered is not None
+          self._output_pre_backward_hook_registered.clear()
           if self.optimization_barrier_in_backward:
             # Ensure that backward pass ops of feature gradients, parameter
             # gradient and sharding, and full-param freeing (which are usually


### PR DESCRIPTION
The python-related objects of activations may be released during execution, leading to occasional identical values for different tensors' id(tensor). Consequently, some tensors may not have barriers added, triggering recompilation.