### PR TITLE
Support PyTorch CUDACachingAllocator

### DIFF
--- a/torch_xla/csrc/runtime/BUILD
+++ b/torch_xla/csrc/runtime/BUILD
@@ -204,6 +204,7 @@ cc_library(
     ":profiler",
     ":sys_util",
     ":tf_logging",
+    ":torch_allocator",
     ":xla_coordinator",
     "@xla//xla/service:gpu_plugin",
     "@xla//xla/pjrt/gpu:se_gpu_pjrt_client",
@@ -368,6 +369,18 @@ cc_library(
     deps = [
         "@xla//xla:statusor",
         "@xla//xla/service:platform_util",
+    ],
+)
+
+cc_library(
+    name = "torch_allocator",
+    srcs = ["torch_allocator.cc"],
+    hdrs = ["torch_allocator.h"],
+    deps = [
+        ":tf_logging",
+        "@tsl//tsl/framework:allocator",
+        "@torch//:headers",
+        "@xla//xla/stream_executor/gpu:gpu_types_header",
     ],
 )
 

--- a/torch_xla/csrc/runtime/env_vars.cc
+++ b/torch_xla/csrc/runtime/env_vars.cc
@@ -24,6 +24,7 @@ const char* const kEnvPjrtAllocatorCudaAsync = "PJRT_ALLOCATOR_CUDA_ASYNC";
 const char* const kEnvPjrtAllocatorPreallocate = "PJRT_ALLOCATOR_PREALLOCATE";
 const char* const kEnvPjrtAllocatorFraction = "PJRT_ALLOCATOR_FRACTION";
 const char* const kEnvPjrtDynamicPlugins = "PJRT_DYNAMIC_PLUGINS";
+const char* const kEnvPjrtUseTorchAllocator = "PJRT_USE_TORCH_ALLOCATOR";
 
 }  // namespace env
 }  // namespace runtime

--- a/torch_xla/csrc/runtime/env_vars.h
+++ b/torch_xla/csrc/runtime/env_vars.h
@@ -34,6 +34,7 @@ extern const char* const kEnvPjrtAllocatorCudaAsync;
 extern const char* const kEnvPjrtAllocatorPreallocate;
 extern const char* const kEnvPjrtAllocatorFraction;
 extern const char* const kEnvPjrtDynamicPlugins;
+extern const char* const kEnvPjrtUseTorchAllocator;
 
 }  // namespace env
 }  // namespace runtime

--- a/torch_xla/csrc/runtime/torch_allocator.cc
+++ b/torch_xla/csrc/runtime/torch_allocator.cc
@@ -1,0 +1,52 @@
+#include "torch_xla/csrc/runtime/torch_allocator.h"
+
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include "torch_xla/csrc/runtime/tf_logging.h"
+
+namespace torch_xla {
+namespace runtime {
+
+TorchCUDACachingAllocator::TorchCUDACachingAllocator(int device_ordinal) {
+  VLOG(3) << "Creating TorchCUDACachingAllocator for device " << device_ordinal;
+  name_ = c10::cuda::CUDACachingAllocator::name();
+  cuda_stream_ = nullptr;
+  device_index_ = static_cast<c10::DeviceIndex>(device_ordinal);
+}
+
+void* TorchCUDACachingAllocator::AllocateRaw(size_t alignment,
+                                             size_t num_bytes) {
+  CHECK(cuda_stream_ != nullptr)
+      << "A stream must be added to the TorchCUDACachingAllocator allocator";
+  if (num_bytes == 0) {
+    return nullptr;
+  }
+  at::cuda::CUDAGuard device_guard{device_index_};
+  auto ptr = c10::cuda::CUDACachingAllocator::raw_alloc_with_stream(
+      num_bytes, cuda_stream_);
+  VLOG(3) << "Alloc num_bytes " << num_bytes << " with ptr " << ptr
+          << " for device " << static_cast<int>(device_index_);
+  return ptr;
+}
+
+void TorchCUDACachingAllocator::DeallocateRaw(void* ptr) {
+  VLOG(3) << "Dealloc ptr " << ptr << " for device "
+          << static_cast<int>(device_index_);
+  c10::cuda::CUDACachingAllocator::raw_delete(ptr);
+}
+
+void TorchCUDACachingAllocator::SetStreamAndPreallocateMemory(void* stream) {
+  auto new_cuda_stream = static_cast<cudaStream_t>(stream);
+  if (cuda_stream_ != nullptr && new_cuda_stream != cuda_stream_) {
+    LOG(FATAL) <<  // Crash OK.
+        "Trying to set the stream twice. This isn't supported. ";
+  }
+  VLOG(3) << "Setting cuda stream " << stream
+          << " for TorchCUDACachingAllocator on device "
+          << static_cast<int>(device_index_);
+  cuda_stream_ = new_cuda_stream;
+}
+
+}  // namespace runtime
+}  // namespace torch_xla

--- a/torch_xla/csrc/runtime/torch_allocator.cc
+++ b/torch_xla/csrc/runtime/torch_allocator.cc
@@ -38,10 +38,6 @@ void TorchCUDACachingAllocator::DeallocateRaw(void* ptr) {
 
 void TorchCUDACachingAllocator::SetStreamAndPreallocateMemory(void* stream) {
   auto new_cuda_stream = static_cast<cudaStream_t>(stream);
-  if (cuda_stream_ != nullptr && new_cuda_stream != cuda_stream_) {
-    LOG(FATAL) <<  // Crash OK.
-        "Trying to set the stream twice. This isn't supported. ";
-  }
   VLOG(3) << "Setting cuda stream " << stream
           << " for TorchCUDACachingAllocator on device "
           << static_cast<int>(device_index_);

--- a/torch_xla/csrc/runtime/torch_allocator.h
+++ b/torch_xla/csrc/runtime/torch_allocator.h
@@ -1,0 +1,37 @@
+#ifndef XLA_CLIENT_TORCH_ALLOCATOR_H_
+#define XLA_CLIENT_TORCH_ALLOCATOR_H_
+
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_runtime_api.h>
+
+#include "tsl/framework/allocator.h"
+
+namespace torch_xla {
+namespace runtime {
+
+class TorchCUDACachingAllocator : public tsl::Allocator {
+ public:
+  TorchCUDACachingAllocator(int device_ordinal);
+  ~TorchCUDACachingAllocator() override{};
+
+  std::string Name() override { return name_; }
+
+  void* AllocateRaw(size_t alignment, size_t num_bytes) override;
+  void DeallocateRaw(void* ptr) override;
+
+  void SetStreamAndPreallocateMemory(void* stream) override;
+
+  tsl::AllocatorMemoryType GetMemoryType() const override {
+    return tsl::AllocatorMemoryType::kDevice;
+  }
+
+ private:
+  std::string name_;
+  cudaStream_t cuda_stream_;
+  c10::DeviceIndex device_index_;
+};
+
+}  // namespace runtime
+}  // namespace torch_xla
+
+#endif  // XLA_CLIENT_TORCH_ALLOCATOR_H_


### PR DESCRIPTION
* Setting `export PJRT_USE_TORCH_ALLOCATOR=1` to use PyTorch CUDACachingAllocator