### PR TITLE
optimize dynamo + xla backend

### DIFF
--- a/torch_xla/_dynamo/config.py
+++ b/torch_xla/_dynamo/config.py
@@ -16,3 +16,6 @@ outside_on_cuda = False
 
 # Whether to mark step after each layer when early_sync happens.
 mark_step_after_layer_if_early_sync = False
+
+# whether to remove the sync of xla run_cached_graph in dynamo + xla backend.
+no_xla_graph_sync = False

--- a/torch_xla/_dynamo/dynamo_bridge.py
+++ b/torch_xla/_dynamo/dynamo_bridge.py
@@ -184,6 +184,22 @@ def _maybe_move_tensors_to_device(tensors: tuple,
   return tuple(moved_tensors)
 
 
+# Given an input list, moves the tensors from xla device to the cuda device.
+# The output order will be the same as the input. Non tensors will also still
+# be in the list.
+def _move_tensors_to_cuda_device(input_tensors: tuple, result_tensors: tuple,
+                                 data_pointers):
+  moved_tensors = []
+  for (input_tensor, result_tensor,
+       data_pointer) in zip(input_tensors, result_tensors, data_pointers):
+    moved_tensor = torch_xla_dlpack.from_xla_cuda_to_cuda_alias(
+        input_tensor, result_tensor, data_pointer)
+    moved_tensor.requires_grad = result_tensor.requires_grad
+    moved_tensors.append(moved_tensor)
+
+  return tuple(moved_tensors)
+
+
 def _split_xla_args_tensor_sym_constant(args):
   tensors = deque(maxlen=len(args))
   constants = []
@@ -330,10 +346,34 @@ def extract_graph_helper(xla_model: torch.fx.GraphModule,
                                                                        float],
                                                                  ...],
                                                            Tuple[Any, ...]]):
+  if config.no_xla_graph_sync:
+    # add inputs with same shape and dtype as the output of fx_graph.
+    fx_output_dtype = xla_model.xla_out_dtype
+    fx_output_shape = xla_model.xla_out_shape
+    alias_output = []
+
+    if fx_output_dtype is not None:
+      for dtype, shape in zip(fx_output_dtype, fx_output_shape):
+        alias_output.append(
+            torch.zeros(shape, dtype=dtype, device=xm.xla_device()))
+
+    del fx_output_dtype, fx_output_shape
   # Don't reset the scope as we might be under some profiler trace scope.
   xm.mark_step(reset_scope=False)
   # FX Graph inputs passed from Dynamo. xla_args are XLA Tensors.
   xla_args = xla_model.xla_args
+  xla_args_to_run = xla_args
+  
+  if config.no_xla_graph_sync:
+    xla_args = list(xla_args)
+    for output in alias_output:
+      xla_args.append(output)
+
+    for tensor in alias_output:
+      torch_xla._XLAC._set_buffer_donation(tensor, True)
+    torch_xla._XLAC._xla_optimization_barrier_(alias_output)
+  xla_args = tuple(xla_args)
+
   # check [Note: Dynamo real-time input-shape cache look-up]
   # xla_arg might contain symint and we want to filter it out in some use cases.
   # We want to use `xla_args` instead of `xla_args_tensor_only` only when we do
@@ -385,15 +425,29 @@ def extract_graph_helper(xla_model: torch.fx.GraphModule,
     xla_args_sharding_spec = ()
 
   # To trace the model we need `xla_args` instead of `xla_args_tensor_only`
-  xla_out = xla_model(*xla_args)
+  xla_out = xla_model(*xla_args_to_run)
   if not isinstance(xla_out, (tuple, list)):
     xla_out = (xla_out,)
+  
+  if config.no_xla_graph_sync:
+    # make the inputs we add stay in the xla graph;
+    for idx, out in enumerate(xla_out):
+      # scalar tensor
+      if alias_output[idx].dim() == 0:
+        alias_output[idx].add_(out)
+      else:
+        alias_output[idx][:] = out
 
+      torch._functionalize_sync(alias_output[idx])
+  if config.no_xla_graph_sync:
+    xla_out_ids = {id(x) for x in (tuple(xla_out) + tuple(alias_output))}
+  else:
+    xla_out_ids = {id(x) for x in tuple(xla_out)}
+    
   none_remover = NoneRemover()
   none_remover.remove_nones(xla_out)
-
-  xla_out_ids = {id(x) for x in xla_out}
-
+  if config.no_xla_graph_sync:
+    none_remover.remove_nones(alias_output)
   # If an arg is being in place updated by model, we need to include arg as part of the graph result.
   xla_args_need_update_bool = torch_xla._XLAC._check_tensor_need_materialization(
       [tensor for _, tensor in index_and_xla_tensor_args])
@@ -408,8 +462,11 @@ def extract_graph_helper(xla_model: torch.fx.GraphModule,
       arg_index_to_need_update_index[index] = len(xla_args_need_update)
       arg_index_to_update_output_index[i] = len(xla_args_need_update)
       xla_args_need_update.append(tensor)
-
-  args_and_out = tuple(xla_args_need_update) + tuple(xla_out)
+  
+  if config.no_xla_graph_sync:
+    args_and_out = tuple(xla_args_need_update) + tuple(alias_output)
+  else:
+    args_and_out = tuple(xla_args_need_update) + tuple(xla_out)
   # args_and_out should be tensor only, in the dynamic cases there might be
   # symint or symfloat return as the result. In that case we want to extract them and separate
   # them from the device computation.
@@ -549,7 +606,7 @@ def extract_internal(xla_model: torch.fx.GraphModule):
     nonlocal skip_checking_input_sharding_threashold
     nonlocal sym_constants_to_graph_vars
     nonlocal graph_hash
-
+s
     original_device: torch.device = _get_input_arg_device(args)
     is_cuda_args: bool = False
     if original_device:
@@ -558,6 +615,28 @@ def extract_internal(xla_model: torch.fx.GraphModule):
       is_cuda_args = config.outside_on_cuda
       if is_cuda_args:
         original_device = torch.device(torch.cuda.current_device())
+
+    if config.no_xla_graph_sync:
+      args = list(args)
+      fx_output_dtype = xla_model.xla_out_dtype
+      fx_output_shape = xla_model.xla_out_shape
+
+      alias_output = []
+      if fx_output_dtype is not None:
+        for (dtype, shape) in zip(fx_output_dtype, fx_output_shape):
+          # scalar tensor
+          if len(shape) == 0:
+            alias_output.append(
+                torch.zeros(
+                    shape, dtype=dtype, device=original_device))
+          else:
+            alias_output.append(
+                torch.empty(
+                    tuple(shape), dtype=dtype, device=original_device))
+
+      for idx, out in enumerate(alias_output):
+        args.append(out)
+      args = tuple(args)
 
     # See [Note: Dynamo real-time input-shape cache look-up] above.
     xla_args_tensor_only, sym_constants = _split_xla_args_tensor_sym_constant(
@@ -588,6 +667,13 @@ def extract_internal(xla_model: torch.fx.GraphModule):
         args[index] = arg.to(xla_args_dtype[index])
       if isinstance(arg, torch.Tensor) and arg.device.type == "cpu":
         args[index] = arg.to(xm.xla_device())
+
+    if config.no_xla_graph_sync:
+      # get the address of graph inputs.
+      data_pointer = []
+      for arg in args:
+        data_pointer.append(arg.data_ptr())
+
     if is_cuda_args:
       args = _maybe_move_tensors_to_device(args, xm.xla_device())
     xla_args_tensor_only, sym_constants = _split_xla_args_tensor_sym_constant(
@@ -632,7 +718,6 @@ def extract_internal(xla_model: torch.fx.GraphModule):
 
     # graph input should be tensor only
     graph_input = graph_input_matcher(xla_args_tensor_only)
-
     for a in graph_input:
       torch._functionalize_sync(a)
 
@@ -643,8 +728,13 @@ def extract_internal(xla_model: torch.fx.GraphModule):
           "xla::_call_computation", graph_input, xla_computation,
           xla_args_tensor_only, arg_index_to_update_output_index)
     else:
-      res = torch_xla._XLAC._run_cached_graph(graph_hash, graph_input)
-      xm.wait_device_ops()
+      if config.no_xla_graph_sync:
+        xm.wait_device_ops()
+        res = torch_xla._XLAC._run_cached_graph(graph_hash, graph_input)
+      else:
+        res = torch_xla._XLAC._run_cached_graph(graph_hash, graph_input)
+        xm.wait_device_ops()
+
     res = special_return_handler.addDumbReturn(xla_args_tensor_only, res)
 
     assert len(res) == len_args_and_out, f"{len(res)} v.s. {len_args_and_out}"
@@ -654,15 +744,37 @@ def extract_internal(xla_model: torch.fx.GraphModule):
       for arg_index, res_index in arg_index_to_need_update_index.items():
         args[arg_index].copy_(res[res_index])
         torch._functionalize_sync(args[arg_index])
-
+    
     # First few elements might be xla_args that needs to be in place updated
-    result = res[len_xla_args_need_update:]
-
+    if config.no_xla_graph_sync:
+      result = res[(len_xla_args_need_update - len(alias_output)):]
+    else:
+      result = res[len_xla_args_need_update:]
+    
     none_remover.add_nones(result)
 
     if is_cuda_args:
-      result = _maybe_move_tensors_to_device(tuple(result), original_device)
-
+      if config.no_xla_graph_sync:
+        tensor_id_map = {}
+        for idx, arg in enumerate(xla_args_tensor_only):
+          tensor_id_map[id(arg)] = idx
+        # get the graph input idx aliased with each graph output
+        input_aliased_id = torch_xla._XLAC._get_alias_info(graph_hash,
+                                                          len(graph_input),
+                                                          len(alias_output))
+        data_pointer_to_dlpack = []
+        # the correct order of input address to dlpack
+        for i in input_aliased_id:
+          data_pointer_to_dlpack.append(data_pointer[tensor_id_map[id(
+              graph_input[i])]])
+        
+        # wait until the xla graph finish kernel launch.
+        torch_xla._XLAC._block_until_launch()
+        result = _move_tensors_to_cuda_device(
+            tuple(args[-len(alias_output):]), tuple(result), data_pointer_to_dlpack)
+      else:
+        result = _maybe_move_tensors_to_device(tuple(result), original_device)
+        
     if len(result) == 1:
       return result[0]
     else:
@@ -744,7 +856,21 @@ class InputCollector(torch.fx.Interpreter):
     if "fused_" in target:
       submod = self.fetch_attr(target)
       submod.xla_args = args
-    return super().call_module(target, args, kwargs)
+    xla_out = super().call_module(target, args, kwargs)
+    if not isinstance(xla_out, (tuple, list)):
+      xla_out = (xla_out,)
+    if config.no_xla_graph_sync:
+      xla_out_dtype = []
+      xla_out_shape = []
+      for out in xla_out:
+        xla_out_dtype.append(out.dtype)
+        xla_out_shape.append(out.shape)
+      
+      if "fused_" in target:
+        submod.xla_out_dtype = xla_out_dtype
+        submod.xla_out_shape = xla_out_shape
+
+    return xla_out
 
 
 class XLAConstructorMoverPass(ConstructorMoverPass):
@@ -904,12 +1030,6 @@ def partition_fx_graph_for_cpu_fallback(xla_model, xla_args, all_xla_args,
 def extract_compiled_graph_helper(xla_model: torch.fx.GraphModule, xla_args):
   if _args_on_cuda(xla_args):
     xla_args = tuple(_maybe_move_tensors_to_device(xla_args, xm.xla_device()))
-
-  if not config.outside_on_cuda:
-    xla_args = list(xla_args)
-    for i, arg in enumerate(xla_args):
-      if isinstance(arg, torch.Tensor) and arg.device.type == "cpu":
-        xla_args[i] = arg.to(xm.xla_device())
 
   # Synchronize xla_args, so that each FunctionalTensorWrapper argument updates its
   # value reference before actually computing it.

--- a/torch_xla/_dynamo/dynamo_bridge.py
+++ b/torch_xla/_dynamo/dynamo_bridge.py
@@ -363,7 +363,7 @@ def extract_graph_helper(xla_model: torch.fx.GraphModule,
   # FX Graph inputs passed from Dynamo. xla_args are XLA Tensors.
   xla_args = xla_model.xla_args
   xla_args_to_run = xla_args
-  
+
   if config.no_xla_graph_sync:
     xla_args = list(xla_args)
     for output in alias_output:
@@ -428,7 +428,7 @@ def extract_graph_helper(xla_model: torch.fx.GraphModule,
   xla_out = xla_model(*xla_args_to_run)
   if not isinstance(xla_out, (tuple, list)):
     xla_out = (xla_out,)
-  
+
   if config.no_xla_graph_sync:
     # make the inputs we add stay in the xla graph;
     for idx, out in enumerate(xla_out):
@@ -443,7 +443,7 @@ def extract_graph_helper(xla_model: torch.fx.GraphModule,
     xla_out_ids = {id(x) for x in (tuple(xla_out) + tuple(alias_output))}
   else:
     xla_out_ids = {id(x) for x in tuple(xla_out)}
-    
+
   none_remover = NoneRemover()
   none_remover.remove_nones(xla_out)
   if config.no_xla_graph_sync:
@@ -462,7 +462,7 @@ def extract_graph_helper(xla_model: torch.fx.GraphModule,
       arg_index_to_need_update_index[index] = len(xla_args_need_update)
       arg_index_to_update_output_index[i] = len(xla_args_need_update)
       xla_args_need_update.append(tensor)
-  
+
   if config.no_xla_graph_sync:
     args_and_out = tuple(xla_args_need_update) + tuple(alias_output)
   else:
@@ -606,7 +606,7 @@ def extract_internal(xla_model: torch.fx.GraphModule):
     nonlocal skip_checking_input_sharding_threashold
     nonlocal sym_constants_to_graph_vars
     nonlocal graph_hash
-s
+
     original_device: torch.device = _get_input_arg_device(args)
     is_cuda_args: bool = False
     if original_device:
@@ -627,12 +627,10 @@ s
           # scalar tensor
           if len(shape) == 0:
             alias_output.append(
-                torch.zeros(
-                    shape, dtype=dtype, device=original_device))
+                torch.zeros(shape, dtype=dtype, device=original_device))
           else:
             alias_output.append(
-                torch.empty(
-                    tuple(shape), dtype=dtype, device=original_device))
+                torch.empty(tuple(shape), dtype=dtype, device=original_device))
 
       for idx, out in enumerate(alias_output):
         args.append(out)
@@ -744,13 +742,13 @@ s
       for arg_index, res_index in arg_index_to_need_update_index.items():
         args[arg_index].copy_(res[res_index])
         torch._functionalize_sync(args[arg_index])
-    
+
     # First few elements might be xla_args that needs to be in place updated
     if config.no_xla_graph_sync:
       result = res[(len_xla_args_need_update - len(alias_output)):]
     else:
       result = res[len_xla_args_need_update:]
-    
+
     none_remover.add_nones(result)
 
     if is_cuda_args:
@@ -759,22 +757,22 @@ s
         for idx, arg in enumerate(xla_args_tensor_only):
           tensor_id_map[id(arg)] = idx
         # get the graph input idx aliased with each graph output
-        input_aliased_id = torch_xla._XLAC._get_alias_info(graph_hash,
-                                                          len(graph_input),
-                                                          len(alias_output))
+        input_aliased_id = torch_xla._XLAC._get_alias_info(
+            graph_hash, len(graph_input), len(alias_output))
         data_pointer_to_dlpack = []
         # the correct order of input address to dlpack
         for i in input_aliased_id:
           data_pointer_to_dlpack.append(data_pointer[tensor_id_map[id(
               graph_input[i])]])
-        
+
         # wait until the xla graph finish kernel launch.
         torch_xla._XLAC._block_until_launch()
         result = _move_tensors_to_cuda_device(
-            tuple(args[-len(alias_output):]), tuple(result), data_pointer_to_dlpack)
+            tuple(args[-len(alias_output):]), tuple(result),
+            data_pointer_to_dlpack)
       else:
         result = _maybe_move_tensors_to_device(tuple(result), original_device)
-        
+
     if len(result) == 1:
       return result[0]
     else:
@@ -865,7 +863,7 @@ class InputCollector(torch.fx.Interpreter):
       for out in xla_out:
         xla_out_dtype.append(out.dtype)
         xla_out_shape.append(out.shape)
-      
+
       if "fused_" in target:
         submod.xla_out_dtype = xla_out_dtype
         submod.xla_out_shape = xla_out_shape

--- a/torch_xla/_dynamo/dynamo_bridge.py
+++ b/torch_xla/_dynamo/dynamo_bridge.py
@@ -192,6 +192,13 @@ def _move_tensors_to_cuda_device(input_tensors: tuple, result_tensors: tuple,
   moved_tensors = []
   for (input_tensor, result_tensor,
        data_pointer) in zip(input_tensors, result_tensors, data_pointers):
+    if result_tensor.device.type == 'cuda':
+      moved_tensors.append(result_tensor)
+      continue
+
+    if dynamo_debug:
+      print("moving xla tensor to cuda tensor before xla graph sync.")
+
     moved_tensor = torch_xla_dlpack.from_xla_cuda_to_cuda_alias(
         input_tensor, result_tensor, data_pointer)
     moved_tensor.requires_grad = result_tensor.requires_grad
@@ -347,7 +354,7 @@ def extract_graph_helper(xla_model: torch.fx.GraphModule,
                                                                  ...],
                                                            Tuple[Any, ...]]):
   if config.no_xla_graph_sync:
-    # add inputs with same shape and dtype as the output of fx_graph.
+    # add inputs with same shape and dtype as the outputs of fx_graph.
     fx_output_dtype = xla_model.xla_out_dtype
     fx_output_shape = xla_model.xla_out_shape
     alias_output = []
@@ -368,7 +375,8 @@ def extract_graph_helper(xla_model: torch.fx.GraphModule,
     xla_args = list(xla_args)
     for output in alias_output:
       xla_args.append(output)
-
+    
+    # donate alias_output as input with output manully.
     for tensor in alias_output:
       torch_xla._XLAC._set_buffer_donation(tensor, True)
     torch_xla._XLAC._xla_optimization_barrier_(alias_output)

--- a/torch_xla/csrc/dl_convertor.cpp
+++ b/torch_xla/csrc/dl_convertor.cpp
@@ -30,6 +30,15 @@ struct DLPackTensor {
   DLManagedTensor tensor;
 };
 
+struct DLPackTensorAlias {
+  ~DLPackTensorAlias() {}
+  XLATensorPtr reference;
+
+  std::vector<int64_t> shape;
+  std::vector<int64_t> strides;
+  DLManagedTensor tensor;
+};
+
 DLPackTensor::~DLPackTensor() {
   if (external_reference) {
     external_reference.reset(nullptr);
@@ -39,6 +48,12 @@ DLPackTensor::~DLPackTensor() {
 void DLPackTensorDeleter(DLManagedTensor* t) {
   if (t) {
     delete static_cast<DLPackTensor*>(t->manager_ctx);
+  }
+}
+
+void DLPackTensorAliasDeleter(DLManagedTensor* t) {
+  if (t) {
+    delete static_cast<DLPackTensorAlias*>(t->manager_ctx);
   }
 }
 
@@ -145,6 +160,45 @@ DLManagedTensor* toDLPack(const at::Tensor& input) {
   dt.data = pack->external_reference->OpaqueDeviceMemoryDataPointer();
   pack->tensor.manager_ctx = pack.get();
   pack->tensor.deleter = DLPackTensorDeleter;
+  dt.device = DLDeviceForDevice(*pjrt_buffer->device());
+  dt.device.device_id = pjrt_buffer->device()->local_hardware_id();
+  dt.ndim = pjrt_buffer->dimensions().size();
+  dt.dtype = PrimitiveTypeToDLDataType(pjrt_buffer->element_type());
+
+  pack->shape = std::vector<int64_t>(pjrt_buffer->dimensions().begin(),
+                                     pjrt_buffer->dimensions().end());
+  xla::Layout xla_layout = xla::GetXlaLayoutUnsafe(pjrt_buffer->layout());
+  pack->strides = StridesForShape(pjrt_buffer->element_type(),
+                                  pjrt_buffer->dimensions(), xla_layout);
+  dt.shape = reinterpret_cast<std::int64_t*>(pack->shape.data());
+  dt.strides = reinterpret_cast<std::int64_t*>(pack->strides.data());
+  dt.byte_offset = 0;
+
+  return &(pack.release()->tensor);
+}
+
+// convert an XLA tensor to a dlpack tensor
+DLManagedTensor* toDLPackAlias(const at::Tensor& input,
+                               const at::Tensor& result, int64_t address) {
+  void* data = reinterpret_cast<void*>(address);
+
+  auto pack = std::make_unique<DLPackTensorAlias>();
+  DLTensor& dt = pack->tensor.dl_tensor;
+
+  std::shared_ptr<runtime::ComputationClient::Data> handle =
+      get_data_handle(input);
+  XLATensorPtr xla_tensor_ptr = bridge::TryGetXlaTensor(result);
+  pack->reference = xla_tensor_ptr;
+  XLA_CHECK(handle != nullptr)
+      << "Could not extract a valid data handle from the input tensor";
+
+  std::shared_ptr<xla::PjRtBuffer> pjrt_buffer =
+      runtime::GetComputationClient()->GetPjRtBuffer(handle);
+  XLA_CHECK(pjrt_buffer != nullptr) << "Could not get a valid pjrt_buffer";
+
+  dt.data = data;
+  pack->tensor.manager_ctx = pack.get();
+  pack->tensor.deleter = DLPackTensorAliasDeleter;
   dt.device = DLDeviceForDevice(*pjrt_buffer->device());
   dt.device.device_id = pjrt_buffer->device()->local_hardware_id();
   dt.ndim = pjrt_buffer->dimensions().size();

--- a/torch_xla/csrc/dl_convertor.h
+++ b/torch_xla/csrc/dl_convertor.h
@@ -7,6 +7,8 @@
 namespace torch_xla {
 
 DLManagedTensor* toDLPack(const at::Tensor& src);
+DLManagedTensor* toDLPackAlias(const at::Tensor& input,
+                               const at::Tensor& result, int64_t address);
 at::Tensor fromDLPack(DLManagedTensor* src);
 
 }  // namespace torch_xla

--- a/torch_xla/csrc/init_python_bindings.cpp
+++ b/torch_xla/csrc/init_python_bindings.cpp
@@ -1315,6 +1315,12 @@ void InitXlaModuleBindings(py::module m) {
   m.def("_get_stream_for_cuda_device", [](const int device_id) {
     return runtime::GetComputationClient()->GetCudaStreamForDevice(device_id);
   });
+  // currently we cannot set stream allocated outside xla by streamid;
+  m.def("_set_stream_from_cuda_device",
+        [](const std::intptr_t stream, const int device_id) {
+          return runtime::GetComputationClient()->SetCudaStreamForDevice(
+              stream, device_id);
+        });
   m.def("_xla_num_devices", []() -> int64_t {
     if (UseVirtualDevice()) {
       return 1;
@@ -2498,6 +2504,21 @@ void InitXlaModuleBindings(py::module m) {
     return false;
   });
 
+  m.def("_get_alias_info",
+        [](const std::string& hash_str, int64_t input_num,
+           int64_t output_num) -> std::vector<int64_t> {
+          XLA_CHECK(hash_str.size() == sizeof(torch::lazy::hash_t));
+          torch::lazy::hash_t hash = *(torch::lazy::hash_t*)(hash_str.c_str());
+
+          auto aliasedparams = XLAGraphExecutor::Get()->GetAliasInfo(
+              hash, input_num, output_num);
+          return aliasedparams;
+        });
+
+  m.def("_block_until_launch", []() -> void {
+    XLAGraphExecutor::LaunchLocker::Get()->WaitUntilCanLock();
+  });
+
   // -------------FlashAttention Integration API Start-----------------
   m.def("_flash_attention_forward",
         [](const at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
@@ -2705,6 +2726,18 @@ void InitXlaModuleBindings(py::module m) {
     }
     return PyCapsule_New(dlMTensor, "dltensor", dlPack_Capsule_Destructor);
   });
+
+  m.def("_to_dlpack_alias",
+        [](const at::Tensor& input, const at::Tensor& result,
+           int64_t data_pointer) -> py::handle {
+          DLManagedTensor* dlMTensor;
+          {
+            NoGilSection nogil;
+            dlMTensor = torch_xla::toDLPackAlias(input, result, data_pointer);
+          }
+          return PyCapsule_New(dlMTensor, "dltensor",
+                               dlPack_Capsule_Destructor);
+        });
 
   // from a dlpack PyCapsule to an XLA tensor
   // If ext_data is the result of an CUDA computation, we should synchronize

--- a/torch_xla/csrc/runtime/computation_client.h
+++ b/torch_xla/csrc/runtime/computation_client.h
@@ -265,6 +265,9 @@ class ComputationClient {
       std::string device, xla::Shape shape,
       std::optional<xla::OpSharding> sharding = std::nullopt) = 0;
 
+  virtual std::vector<int64_t> GetAliasInfo(
+      const runtime::ComputationClient::ComputationPtr computation,
+      int64_t input_num, int64_t output_num) = 0;
   // Returns data shards. We expect this to be called on PjRtShardedData to
   // retrieve the shards. If other data type is passed, it returns the input
   // wrapped inside a vector.
@@ -363,6 +366,12 @@ class ComputationClient {
       int local_device_id) const = 0;
 
   virtual std::intptr_t GetCudaStreamForDevice(int local_device_id) const = 0;
+
+  virtual void SetCudaStreamForDevice(std::intptr_t stream,
+                                      int local_device_id) const = 0;
+
+  virtual void WaitCudaStreamForDevice(
+      const torch::lazy::BackendDevice& device) = 0;
 
   virtual size_t GetNumDevices() const = 0;
 

--- a/torch_xla/csrc/runtime/ifrt_computation_client.h
+++ b/torch_xla/csrc/runtime/ifrt_computation_client.h
@@ -95,7 +95,23 @@ class IfrtComputationClient : public ComputationClient {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   }
 
+  virtual std::vector<int64_t> GetAliasInfo(
+      const runtime::ComputationClient::ComputationPtr computation,
+      int64_t input_num, int64_t output_num) override {
+    XLA_ERROR() << __FUNCTION__ << " not implemented";
+  }
+
   std::intptr_t GetCudaStreamForDevice(int local_device_id) const override {
+    XLA_ERROR() << __FUNCTION__ << " not implemented";
+  }
+
+  void SetCudaStreamForDevice(std::intptr_t stream,
+                              int local_device_id) const override {
+    XLA_ERROR() << __FUNCTION__ << " not implemented";
+  }
+
+  void WaitCudaStreamForDevice(
+      const torch::lazy::BackendDevice& device) override {
     XLA_ERROR() << __FUNCTION__ << " not implemented";
   }
 

--- a/torch_xla/csrc/runtime/pjrt_computation_client.cc
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.cc
@@ -680,6 +680,19 @@ torch::lazy::hash_t PjRtComputationClient::HashCompilationEnv() {
   return comp_env_hash_;
 }
 
+std::vector<int64_t> PjRtComputationClient::GetAliasInfo(
+    const runtime::ComputationClient::ComputationPtr computation,
+    int64_t input_num, int64_t output_num) {
+  const PjRtComputation& pjrt_computation =
+      dynamic_cast<const PjRtComputation&>(
+          *std::dynamic_pointer_cast<runtime::ComputationClient::Computation>(
+              computation));
+
+  return pjrt_computation.executable
+      ->GetAliasedParams(0 /*executable_idx*/, input_num, output_num)
+      .value();
+}
+
 std::vector<ComputationClient::DataPtr>
 PjRtComputationClient::ExecuteComputation(
     const ComputationClient::Computation& computation,

--- a/torch_xla/csrc/runtime/pjrt_computation_client.h
+++ b/torch_xla/csrc/runtime/pjrt_computation_client.h
@@ -75,6 +75,10 @@ class PjRtComputationClient : public ComputationClient {
 
   ComputationPtr DeserializeComputation(const std::string& serialized) override;
 
+  std::vector<int64_t> GetAliasInfo(
+      const runtime::ComputationClient::ComputationPtr computation,
+      int64_t input_num, int64_t output_num) override;
+
   std::vector<DataPtr> ExecuteComputation(
       const Computation& computation, absl::Span<const DataPtr> arguments,
       const std::string& device,
@@ -110,9 +114,26 @@ class PjRtComputationClient : public ComputationClient {
             xla::PjRtLocalDeviceId(local_device_id));
     XLA_CHECK(pjrt_device.ok()) << "Failed to get a PjRt device.";
     absl::StatusOr<std::intptr_t> stream =
-        pjrt_device.value()->GetStreamForExternalReadyEvents();
+        pjrt_device.value()->GetLocalComputeStream();
     XLA_CHECK(stream.ok()) << "Failed to get a stream.";
     return stream.value();
+  }
+
+  void SetCudaStreamForDevice(std::intptr_t stream,
+                              int local_device_id) const override {
+    absl::StatusOr<xla::PjRtDevice*> pjrt_device =
+        client_->LookupAddressableDevice(
+            xla::PjRtLocalDeviceId(local_device_id));
+    XLA_CHECK(pjrt_device.ok()) << "Failed to get a PjRt device.";
+    absl::Status status = pjrt_device.value()->SetLocalComputeStream(stream);
+    XLA_CHECK(status.ok()) << "Failed to set a stream.";
+  }
+
+  void WaitCudaStreamForDevice(
+      const torch::lazy::BackendDevice& device) override {
+    xla::PjRtDevice* pjrt_device = StringToPjRtDevice(device.toString());
+    absl::Status block_status = pjrt_device->WaitLocalComputeStream();
+    XLA_CHECK(block_status.ok()) << "Failed to wait a compute stream";
   }
 
   std::vector<std::string> GetLocalDevices() const override;

--- a/torch_xla/csrc/xla_graph_executor.cpp
+++ b/torch_xla/csrc/xla_graph_executor.cpp
@@ -221,6 +221,34 @@ torch::lazy::Value XLAGraphExecutor::DeviceContextArena::IrValueFromScalar(
   return torch::lazy::MakeNode<DeviceData>(std::move(device_data));
 }
 
+void XLAGraphExecutor::LaunchLocker::Lock() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  cv_.wait(lock, [this] { return !locked_; });
+  locked_ = true;
+}
+
+void XLAGraphExecutor::LaunchLocker::Unlock() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  locked_ = false;
+  cv_.notify_all();
+}
+
+void XLAGraphExecutor::LaunchLocker::WaitUntilCanLock() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  cv_.wait(lock, [this] { return !locked_; });
+}
+
+void XLAGraphExecutor::LaunchLocker::Barrier() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  cv_.wait(lock, [this] { return !locked_; });
+  cv_.notify_all();
+}
+
+auto XLAGraphExecutor::LaunchLocker::Get() -> LaunchLocker* {
+  static LaunchLocker* lock = new LaunchLocker();
+  return lock;
+}
+
 XLAGraphExecutor::Async::Async(
     SyncTensorCollection* coll,
     std::vector<torch::lazy::BackendDataPtr> parameters_data,
@@ -354,6 +382,15 @@ void XLAGraphExecutor::SetAliasWithBufferDonorConfig(bool should_alias) {
 
 bool XLAGraphExecutor::GetAliasWithBufferDonorConfig() {
   return DeviceContextArena::Get()->GetAliasWithBufferDonorConfig();
+}
+std::vector<int64_t> XLAGraphExecutor::GetAliasInfo(torch::lazy::hash_t hash,
+                                                    int64_t input_num,
+                                                    int64_t output_num) {
+  auto cachedComputation =
+      XLAGraphExecutor::Get()->GetComputationCache()->Get(hash);
+  auto pjrt_client = runtime::GetComputationClient();
+  return pjrt_client->GetAliasInfo(cachedComputation->computation, input_num,
+                                   output_num);
 }
 
 std::string XLAGraphExecutor::DumpHloComputation(
@@ -855,6 +892,9 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
                    << async->device << " done!";
       }
 
+      LaunchLocker::Get()->Unlock();
+      // block the stream;
+      runtime::GetComputationClient()->WaitCudaStreamForDevice(async->device);
       // Updating placeholder with actual output handle.
       {
         tsl::profiler::TraceMe activity("update_placeholder",
@@ -881,6 +921,8 @@ XLAGraphExecutor::ExecuteComputationWithBarrier(
     }
   };
 
+  // Lock before async
+  LaunchLocker::Get()->Lock();
   thread::Schedule(async->mwait.Completer(std::move(syncfn)));
 
   return placeholders;

--- a/torch_xla/csrc/xla_graph_executor.h
+++ b/torch_xla/csrc/xla_graph_executor.h
@@ -32,6 +32,25 @@ namespace torch_xla {
 class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
  public:
   static XLAGraphExecutor* Get();
+  // Locking:
+  // We perform LaunchLock to ensure the correct order of kernel launch between
+  // graph execution and eager execution in the Scenario of dynamo + xla
+  // backend.
+  class LaunchLocker {
+   public:
+    static LaunchLocker* Get();
+    explicit LaunchLocker() {}
+
+    void Lock();
+    void Unlock();
+    void Barrier();
+    void WaitUntilCanLock();
+
+   private:
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    bool locked_ = false;
+  };
 
   // Override to use our own DeviceContextArena.
   void RegisterTensor(
@@ -100,6 +119,8 @@ class XLAGraphExecutor : public torch::lazy::LazyGraphExecutor {
 
   bool GetAliasWithBufferDonorConfig();
 
+  std::vector<int64_t> GetAliasInfo(torch::lazy::hash_t hash, int64_t input_num,
+                                    int64_t output_num);
   // Dumps the XLA HLO text of the computation accumulated in the graph which is
   // attached the tensors.
   // We don't use upstream DumpBackendComputation given we have our own format.

--- a/torch_xla/utils/dlpack.py
+++ b/torch_xla/utils/dlpack.py
@@ -9,8 +9,11 @@ import torch_xla.utils.utils as xu
 def to_dlpack(xla_tensor: Any):
   return torch_xla._XLAC._to_dlpack(xla_tensor)
 
+
 def to_dlpack_alias(xla_tensor_input: Any, xla_tensor_result, data_pointer):
-  return torch_xla._XLAC._to_dlpack_alias(xla_tensor_input, xla_tensor_result, data_pointer)
+  return torch_xla._XLAC._to_dlpack_alias(xla_tensor_input, xla_tensor_result,
+                                          data_pointer)
+
 
 def from_dlpack(ext_tensor: Any):
   if hasattr(ext_tensor, '__dlpack_device__') and hasattr(
@@ -79,4 +82,3 @@ def from_xla_cuda_to_cuda_alias(input_tensor, result_tensor, data_pointer):
   dlpack = to_dlpack_alias(input_tensor, result_tensor, data_pointer)
   cuda_tensor = torch.utils.dlpack.from_dlpack(dlpack)
   return cuda_tensor
-  

--- a/torch_xla/utils/dlpack.py
+++ b/torch_xla/utils/dlpack.py
@@ -9,6 +9,8 @@ import torch_xla.utils.utils as xu
 def to_dlpack(xla_tensor: Any):
   return torch_xla._XLAC._to_dlpack(xla_tensor)
 
+def to_dlpack_alias(xla_tensor_input: Any, xla_tensor_result, data_pointer):
+  return torch_xla._XLAC._to_dlpack_alias(xla_tensor_input, xla_tensor_result, data_pointer)
 
 def from_dlpack(ext_tensor: Any):
   if hasattr(ext_tensor, '__dlpack_device__') and hasattr(
@@ -50,3 +52,31 @@ def from_xla_cuda_to_cuda(tensor):
   dlpack = to_dlpack(tensor)
   cuda_tensor = torch.utils.dlpack.from_dlpack(dlpack)
   return cuda_tensor
+
+
+def from_xla_cuda_to_cuda_alias(input_tensor, result_tensor, data_pointer):
+  assert torch.cuda.is_available()
+  assert result_tensor.device.type == "xla", "The tensor is not an XLA tensor"
+  is_xla_cuda = True if xu.getenv_as("PJRT_DEVICE", str,
+                                     "").lower() == "cuda" else False
+  assert is_xla_cuda, "The XLA tensor is not on CUDA"
+  # consumer is torch, producer is torch_xla
+
+  # Similar logic as torch.utils.dlpack.from_dlpack
+  # https://github.com/pytorch/pytorch/blob/b0ef363972203b163cddc95e4c6054b8221c2300/torch/utils/dlpack.py#L114-L115
+  # The array API specify that the default legacy stream must be passed
+  # with a value of 1 for CUDA
+  device_id = result_tensor.device.index
+  stream = torch_xla._XLAC._get_stream_for_cuda_device(device_id)
+  stream = 1 if stream == 0 else stream
+  assert stream is None or type(stream) is int
+  external_stream = torch.cuda.ExternalStream(stream)
+  current_stream = torch.cuda.current_stream()
+  if external_stream != current_stream:
+    event = torch.cuda.Event()
+    event.record(current_stream)
+    external_stream.wait_event(event)
+  dlpack = to_dlpack_alias(input_tensor, result_tensor, data_pointer)
+  cuda_tensor = torch.utils.dlpack.from_dlpack(dlpack)
+  return cuda_tensor
+  


### PR DESCRIPTION
What this pr do:
1. remove wait after run_cached_graph in dynamo + xla backend.
2. add no_xla_graph_sync config to control whether to  wait after run_cached_graph.